### PR TITLE
Fixed generated urls not matching webmocks for `nil` parameters.

### DIFF
--- a/spec/youku/v2/users_spec.rb
+++ b/spec/youku/v2/users_spec.rb
@@ -9,7 +9,7 @@ describe Youku::V2::Users do
     let(:url)   { 'https://openapi.youku.com/v2/users/show_batch.json' }
     let(:query) { {
       client_id: client.client_id,
-      user_ids:  nil,
+      user_ids:  '',
       user_names: 'jackie_chan',
     } }
 

--- a/spec/youku/v2/videos_spec.rb
+++ b/spec/youku/v2/videos_spec.rb
@@ -10,7 +10,7 @@ describe Youku::V2::Videos do
     let(:query) { {
       client_id: client.client_id,
       video_ids: 123,
-      ext:       nil,
+      ext:       '',
     } }
 
     before do
@@ -27,7 +27,7 @@ describe Youku::V2::Videos do
     let(:query) { {
       client_id: client.client_id,
       video_id: 123,
-      ext:      nil,
+      ext:      '',
     } }
 
     before do
@@ -44,7 +44,7 @@ describe Youku::V2::Videos do
     let(:query) { {
       client_id: client.client_id,
       user_id:   123,
-      user_name: nil,
+      user_name: '',
       orderby:   'published',
       page:      1,
       count:     20


### PR DESCRIPTION
When running the tests, WebMock would break for any API calls with nil parameters. The reason being, that WebMock would generate a slightly different URL to Typhoeus: (I've indicated the difference)

```
https://openapi.youku.com/v2/videos/show_batch.json?client_id=client-id&ext=&video_ids=123
                                                                           |
https://openapi.youku.com/v2/videos/show_batch.json?client_id=client-id&ext&video_ids=123
```

Changing the parameters from `nil` to `''` to WebMock fixes this.
